### PR TITLE
Update Python Externals dir to include the architecture.

### DIFF
--- a/Source/Core/DolphinQt/DolphinQt.vcxproj
+++ b/Source/Core/DolphinQt/DolphinQt.vcxproj
@@ -38,7 +38,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>avrt.lib;iphlpapi.lib;winmm.lib;setupapi.lib;rpcrt4.lib;comctl32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(ExternalsDir)python\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ExternalsDir)python\$(Platform)\libs;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="'$(Platform)'=='x64'">opengl32.lib;avcodec.lib;avformat.lib;avutil.lib;swresample.lib;swscale.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(ExternalsDir)ffmpeg\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>

--- a/Source/VSProps/PyEmbed.props
+++ b/Source/VSProps/PyEmbed.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- embedded python -->
   <PropertyGroup Label="PyEmbed">
-    <PyExtDir>$(ExternalsDir)python\embed\</PyExtDir>
+    <PyExtDir>$(ExternalsDir)python\$(Platform)\embed\</PyExtDir>
     <PyEmbedOutputDir>$(BinaryOutputDir)python-embed\</PyEmbedOutputDir>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The counterpart to [this pr](https://github.com/Felk/ext-python/pull/1). Should work fine, I had some local build issues unrelated to this as I don't have VS2019 anymore, so I'd recommend doing a quick test after that PR is merged. It's a draft for now, once the counterpart PR is merged I'll update the submodule and mark it as ready for review.