### PR TITLE
Add code breakpoint events.

### DIFF
--- a/Source/Core/Core/API/Events.h
+++ b/Source/Core/Core/API/Events.h
@@ -24,6 +24,10 @@ struct MemoryBreakpoint
   u32 addr;
   u64 value;
 };
+struct CodeBreakpoint
+{
+  u32 addr;
+};
 struct SetInterrupt
 {
   u32 cause_mask;
@@ -96,7 +100,7 @@ public:
 
   void TickListeners()
   {
-      std::lock_guard lock{m_listeners_iterate_mutex};
+    std::lock_guard lock{m_listeners_iterate_mutex};
   }
 private:
   std::mutex m_listeners_iterate_mutex{};
@@ -159,7 +163,7 @@ private:
 
 // all existing events need to be listed here, otherwise there will be spooky templating errors
 using EventHub = GenericEventHub<Events::FrameAdvance, Events::SetInterrupt, Events::ClearInterrupt,
-                                 Events::MemoryBreakpoint>;
+                                 Events::MemoryBreakpoint, Events::CodeBreakpoint>;
 
 // global event hub
 EventHub& GetEventHub();

--- a/Source/Core/Core/PowerPC/BreakPoints.cpp
+++ b/Source/Core/Core/PowerPC/BreakPoints.cpp
@@ -38,6 +38,7 @@ bool BreakPoints::IsTempBreakPoint(u32 address) const
 
 bool BreakPoints::IsBreakPointBreakOnHit(u32 address) const
 {
+  API::GetEventHub().EmitEvent(API::Events::CodeBreakpoint{address});
   return std::any_of(m_breakpoints.begin(), m_breakpoints.end(), [address](const auto& bp) {
     return bp.address == address && bp.break_on_hit;
   });

--- a/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
+++ b/Source/Core/Core/PowerPC/Jit64/JitAsm.cpp
@@ -94,9 +94,10 @@ void Jit64AsmRoutineManager::Generate()
     MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
     TEST(32, MatR(RSCRATCH), Imm32(static_cast<u32>(CPU::State::Stepping)));
     FixupBranch notStepping = J_CC(CC_Z);
-    ABI_PushRegistersAndAdjustStack({}, 0);
-    ABI_CallFunction(PowerPC::CheckBreakPoints);
-    ABI_PopRegistersAndAdjustStack({}, 0);
+    // Causes duplicate hits with jit.cpp
+    // ABI_PushRegistersAndAdjustStack({}, 0);
+    // ABI_CallFunction(PowerPC::CheckBreakPoints);
+    // ABI_PopRegistersAndAdjustStack({}, 0);
     MOV(64, R(RSCRATCH), ImmPtr(CPU::GetStatePtr()));
     TEST(32, MatR(RSCRATCH), Imm32(0xFFFFFFFF));
     dbg_exit = J_CC(CC_NZ, true);

--- a/Source/Core/Scripting/Python/Modules/eventmodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/eventmodule.cpp
@@ -147,7 +147,7 @@ public:
         s_pyevents);
     state->cleanup_listeners.emplace([=]() {
       std::apply([&](const auto&... listener_id) { (state->event_hub->UnlistenEvent(listener_id), ...); },
-                 listener_ids);
+          listener_ids);
     });
   }
   static void UnregisterListeners(EventModuleState* state)
@@ -175,18 +175,24 @@ static const std::tuple<bool, u32, u64> PyMemoryBreakpoint(const API::Events::Me
 {
   return std::make_tuple(evt.write, evt.addr, evt.value);
 }
-
+static const std::tuple<u32> PyCodeBreakpoint(const API::Events::CodeBreakpoint& evt)
+{
+  return std::make_tuple(evt.addr);
+}
 // EVENT DEFINITIONS
 // Creates a PyEvent class from the signature.
 using PyFrameAdvanceEvent = PyEventFromMappingFunc<PyFrameAdvance>;
 using PyMemoryBreakpointEvent = PyEventFromMappingFunc<PyMemoryBreakpoint>;
+using PyCodeBreakpointEvent = PyEventFromMappingFunc<PyCodeBreakpoint>;
 
 // HOOKING UP PY EVENTS TO DOLPHIN EVENTS
 // For all python events listed here, listens to the respective API::Events event
 // deduced from the PyEvent signature's input argument.
-using EventContainer = PythonEventContainer<PyFrameAdvanceEvent, PyMemoryBreakpointEvent>;
+using EventContainer =
+    PythonEventContainer<PyFrameAdvanceEvent, PyMemoryBreakpointEvent, PyCodeBreakpointEvent>;
 template <>
-const std::tuple<PyFrameAdvanceEvent, PyMemoryBreakpointEvent> EventContainer::s_pyevents = {};
+const std::tuple<PyFrameAdvanceEvent, PyMemoryBreakpointEvent, PyCodeBreakpointEvent>
+    EventContainer::s_pyevents = {};
 
 std::optional<CoroutineScheduler> GetCoroutineScheduler(std::string aeventname)
 {
@@ -196,6 +202,7 @@ std::optional<CoroutineScheduler> GetCoroutineScheduler(std::string aeventname)
       // Here, and under the same name in the setup python code
       {"frameadvance", PyFrameAdvanceEvent::ScheduleCoroutine},
       {"memorybreakpoint", PyMemoryBreakpointEvent::ScheduleCoroutine},
+      {"codebreakpoint", PyCodeBreakpointEvent::ScheduleCoroutine},
   };
   auto iter = lookup.find(aeventname);
   if (iter == lookup.end())
@@ -219,6 +226,9 @@ async def frameadvance():
 
 async def memorybreakpoint():
     return (await _DolphinAsyncEvent("memorybreakpoint"))
+
+async def codebreakpoint():
+    return (await _DolphinAsyncEvent("codebreakpoint"))
 )";
   Py::Object result = Py::LoadPyCodeIntoModule(module, pycode);
   if (result.IsNull())
@@ -239,6 +249,7 @@ PyMODINIT_FUNC PyInit_event()
       // Has "on_"-prefix, let's python code register a callback
       Py::MakeMethodDef<PyFrameAdvanceEvent::SetCallback>("on_frameadvance"),
       Py::MakeMethodDef<PyMemoryBreakpointEvent::SetCallback>("on_memorybreakpoint"),
+      Py::MakeMethodDef<PyCodeBreakpointEvent::SetCallback>("on_codebreakpoint"),
 
       {nullptr, nullptr, 0, nullptr}  // Sentinel
   };


### PR DESCRIPTION
Removed duplicate checkbreakpoint call in JitAsm.  May need to be replaced with different fix later.  Produces a double hit if not removed.

Currently there is an issue outside of this PR where all events are returned regardless of how they are marked. Ex: events.codebreakpoint() returns on any event.  In order to test this PR, the return value has to be checked:

```
from dolphin import event

while True:
    try:
        (addr) = await event.codebreakpoint()
        res = len(addr)
    except:
         continue

    if res == 1:
        print(f"{addr[0]:08x}")
```

Not sure if I put the call in BreakPoints.cpp in a weird place. Figured it should be in the same file as the memory BP call.