### PR TITLE
Add emulator reset

### DIFF
--- a/Source/Core/Scripting/Python/Modules/eventmodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/eventmodule.cpp
@@ -18,6 +18,12 @@
 #include "Scripting/Python/Utils/object_wrapper.h"
 #include "Scripting/Python/PyScriptingBackend.h"
 
+#include "Core/Core.h"
+#include "Core/System.h"
+#include "Core/HW/ProcessorInterface.h"
+//#include "DolphinQt/MainWindow.h"
+#include "Core/Movie.h"
+
 namespace PyScripting
 {
 
@@ -311,6 +317,15 @@ static PyObject* Reset(PyObject* module)
   Py_RETURN_NONE;
 }
 
+static PyObject* SystemReset(PyObject* self)
+{
+  // Copy from DolphinQt/MainWindow.cpp: MainWindow::Reset()
+  if (Movie::IsRecordingInput())
+    Movie::SetReset(true);
+  ProcessorInterface::ResetButton_Tap();
+  Py_RETURN_NONE;
+}
+
 PyMODINIT_FUNC PyInit_event()
 {
   static PyMethodDef methods[] = {
@@ -321,6 +336,7 @@ PyMODINIT_FUNC PyInit_event()
       Py::MakeMethodDef<PyCodeBreakpointEvent::SetCallback>("on_codebreakpoint"),
       Py::MakeMethodDef<PyFrameDrawnEvent::SetCallback>("on_framedrawn"),
       Py::MakeMethodDef<Reset>("_dolphin_reset"),
+      Py::MakeMethodDef<SystemReset>("system_reset"),
 
       {nullptr, nullptr, 0, nullptr}  // Sentinel
   };

--- a/Source/Core/Scripting/Python/Modules/eventmodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/eventmodule.cpp
@@ -10,6 +10,8 @@
 
 #include "Common/Logging/Log.h"
 #include "Core/API/Events.h"
+#include "Core/HW/ProcessorInterface.h"
+#include "Core/Movie.h"
 
 #include "Scripting/Python/coroutine.h"
 #include "Scripting/Python/Utils/convert.h"
@@ -17,12 +19,6 @@
 #include "Scripting/Python/Utils/module.h"
 #include "Scripting/Python/Utils/object_wrapper.h"
 #include "Scripting/Python/PyScriptingBackend.h"
-
-#include "Core/Core.h"
-#include "Core/System.h"
-#include "Core/HW/ProcessorInterface.h"
-//#include "DolphinQt/MainWindow.h"
-#include "Core/Movie.h"
 
 namespace PyScripting
 {

--- a/python-stubs/dolphin/event.pyi
+++ b/python-stubs/dolphin/event.pyi
@@ -43,3 +43,9 @@ async def memorybreakpoint() -> (bool, int, int):
     """
     Awaitable event that completes once a previously added memory breakpoint is hit.
     """
+
+
+def system_reset() -> None:
+    """
+    Resets the emulation.
+    """


### PR DESCRIPTION
Added a python function to reset the emulator as talked about in #8 
The function works the same way as the Reset function that is available through the GUI.

A short example that resets the emulation every 20 seconds.
```
from dolphin import event

waittime = 0

while True:
    waittime += 1
    await event.frameadvance()
    if(waittime > 60*20):
        waittime = 0
        print("Reset")
        event.system_reset()
```