### PR TITLE
Update incomplete, partially unknown and broken stubs

### DIFF
--- a/python-stubs/dolphin/__init__.pyi
+++ b/python-stubs/dolphin/__init__.pyi
@@ -1,1 +1,1 @@
-from . import controller, event, gui, memory, savestate
+from . import controller as controller, event as event, gui as gui, memory as memory, savestate as savestate

--- a/python-stubs/dolphin/controller.pyi
+++ b/python-stubs/dolphin/controller.pyi
@@ -4,9 +4,10 @@ Module for programmatic inputs.
 Currently, only for GameCube, Wiimote buttons and Wii IR (pointing).
 No acceleration or extensions data yet.
 """
-from typing import TypedDict
+from typing import TypedDict, type_check_only
 
 
+@type_check_only
 class GCInputs(TypedDict):
     Left: bool
     Right: bool
@@ -31,6 +32,7 @@ class GCInputs(TypedDict):
     Connected: bool
 
 
+@type_check_only
 class WiiInputs(TypedDict):
     Left: bool
     Right: bool
@@ -53,7 +55,7 @@ def get_gc_buttons(controller_id: int, /) -> GCInputs:
     """
 
 
-def set_gc_buttons(controller_id: int, inputs: GCInputs, /):
+def set_gc_buttons(controller_id: int, inputs: GCInputs, /) -> None:
     """
     Sets the current input map for the given GameCube controller.
     The override will hold for the current frame.
@@ -70,7 +72,7 @@ def get_wii_buttons(controller_id: int, /) -> WiiInputs:
     """
 
 
-def set_wii_buttons(controller_id: int, inputs: WiiInputs, /):
+def set_wii_buttons(controller_id: int, inputs: WiiInputs, /) -> None:
     """
     Sets the current input map for the given Wii controller.
     The override will hold for the current frame.
@@ -82,7 +84,7 @@ def set_wii_buttons(controller_id: int, inputs: WiiInputs, /):
 def set_wii_ircamera_transform(controller_id: int,
                                x: float, y: float, z: float = -2,
                                pitch: float = 0, yaw: float = 0,
-                               roll: float = 0, /):
+                               roll: float = 0, /) -> None:
     """
     Places the simulated IR camera at the specified location
     with the specified rotation relative to the sensor bar.

--- a/python-stubs/dolphin/event.pyi
+++ b/python-stubs/dolphin/event.pyi
@@ -4,10 +4,11 @@ Module for awaiting or registering callbacks on all events emitted by Dolphin.
 The odd-looking Protocol classes are just a lot of syntax to essentially describe
 the callback's signature. See https://www.python.org/dev/peps/pep-0544/#callback-protocols
 """
-from typing import Callable, Optional, Protocol
+from typing import Protocol, type_check_only
+from collections.abc import Callable
 
 
-def on_frameadvance(callback: Optional[Callable[[], None]]):
+def on_frameadvance(callback: Callable[[], None] | None) -> None:
     """
     Registers a callback to be called every time the game has rendered a new frame.
     """
@@ -19,6 +20,7 @@ async def frameadvance() -> None:
     """
 
 
+@type_check_only
 class _MemorybreakpointCallback(Protocol):
     def __call__(self, is_write: bool, addr: int, value: int) -> None:
         """
@@ -30,7 +32,7 @@ class _MemorybreakpointCallback(Protocol):
         """
 
 
-def on_memorybreakpoint(callback: Optional[_MemorybreakpointCallback]):
+def on_memorybreakpoint(callback: _MemorybreakpointCallback | None) -> None:
     """
     Registers a callback to be called every time a previously added memory breakpoint is hit.
 
@@ -39,7 +41,7 @@ def on_memorybreakpoint(callback: Optional[_MemorybreakpointCallback]):
     """
 
 
-async def memorybreakpoint() -> (bool, int, int):
+async def memorybreakpoint() -> tuple[bool, int, int]:
     """
     Awaitable event that completes once a previously added memory breakpoint is hit.
     """

--- a/python-stubs/dolphin/gui.pyi
+++ b/python-stubs/dolphin/gui.pyi
@@ -5,10 +5,13 @@ All colors are in ARGB.
 All positions are (x, y) with (0, 0) being top left. X is the horizontal axis.
 """
 
-Position = tuple[float, float]
+from typing_extensions import TypeAlias
 
 
-def add_osd_message(message: str, duration_ms: int = 2000, color: int = 0xFFFFFF30):
+Position: TypeAlias = tuple[float, float]
+
+
+def add_osd_message(message: str, duration_ms: int = 2000, color: int = 0xFFFFFF30) -> None:
     """
     Adds a new message to the on-screen-display.
 
@@ -18,7 +21,7 @@ def add_osd_message(message: str, duration_ms: int = 2000, color: int = 0xFFFFFF
     """
 
 
-def clear_osd_messages():
+def clear_osd_messages() -> None:
     """
     Clear all on-screen-display messages.
     """
@@ -30,76 +33,76 @@ def get_display_size() -> tuple[float, float]:
     """
 
 
-def draw_line(a: Position, b: Position, color: int, thickness: float = 1):
+def draw_line(a: Position, b: Position, color: int, thickness: float = 1) -> None:
     """
     Draws a line from a to b
     """
 
 
-def draw_rect(a: Position, b: Position, color: int, rounding: float = 0, thickness: float = 1):
+def draw_rect(a: Position, b: Position, color: int, rounding: float = 0, thickness: float = 1) -> None:
     """
     Draws a hollow rectangle from a (upper left) to b (lower right)
     """
 
 
-def draw_rect_filled(a: Position, b: Position, color: int, rounding: float = 0):
+def draw_rect_filled(a: Position, b: Position, color: int, rounding: float = 0) -> None:
     """
     Draws a filled rectangle from a (upper left) to b (lower right)
     """
 
 
-def draw_quad(a: Position, b: Position, c: Position, d: Position, color: int, thickness: float = 1):
+def draw_quad(a: Position, b: Position, c: Position, d: Position, color: int, thickness: float = 1) -> None:
     """
     Draws a hollow quad through the points a, b, c and d.
     Points should be defined in clockwise order.
     """
 
 
-def draw_quad_filled(a: Position, b: Position, c: Position, d: Position, color: int):
+def draw_quad_filled(a: Position, b: Position, c: Position, d: Position, color: int) -> None:
     """
     Draws a filled quad through the points a, b, c and d.
     """
 
 
-def draw_triangle(a: Position, b: Position, c: Position, color: int, thickness: float = 1):
+def draw_triangle(a: Position, b: Position, c: Position, color: int, thickness: float = 1) -> None:
     """
     Draws a hollow triangle through the points a, b and c.
     """
 
 
-def draw_triangle_filled(a: Position, b: Position, c: Position, color: int):
+def draw_triangle_filled(a: Position, b: Position, c: Position, color: int) -> None:
     """
     Draws a filled triangle through the points a, b and c.
     """
 
 
-def draw_circle(center: Position, radius: float, color: int, num_segments: int = None, thickness: float = 1):
+def draw_circle(center: Position, radius: float, color: int, num_segments: int | None = None, thickness: float = 1) -> None:
     """
     Draws a hollow circle with the given center point and radius.
     If num_segments is set to None (default), a sensible default is used.
     """
 
 
-def draw_circle_filled(center: Position, radius: float, color: int, num_segments: int = None):
+def draw_circle_filled(center: Position, radius: float, color: int, num_segments: int | None = None) -> None:
     """
     Draws a filled circle with the given center point and radius.
     If num_segments is set to None (default), a sensible default is used.
     """
 
 
-def draw_text(pos: Position, color: int, text: str):
+def draw_text(pos: Position, color: int, text: str) -> None:
     """
     Draws text at a fixed position.
     """
 
 
-def draw_polyline(points: list[Position], color: int, closed: bool = False, thickness: float = 1):
+def draw_polyline(points: list[Position], color: int, closed: bool = False, thickness: float = 1) -> None:
     """
     Draws a line through a list of points
     """
 
 
-def draw_convex_poly_filled(points: list[Position], color: int):
+def draw_convex_poly_filled(points: list[Position], color: int) -> None:
     """
     Draws a convex polygon through a list of points.
     Points should be defined in clockwise order.

--- a/python-stubs/dolphin/memory.pyi
+++ b/python-stubs/dolphin/memory.pyi
@@ -93,7 +93,7 @@ def read_f64(addr: int, /) -> float:
     """
 
 
-def write_u8(addr: int, value: int, /):
+def write_u8(addr: int, value: int, /) -> None:
     """
     Writes an unsigned integer to 1 byte.
     Overflowing values are truncated.
@@ -103,7 +103,7 @@ def write_u8(addr: int, value: int, /):
     """
 
 
-def write_u16(addr: int, value: int, /):
+def write_u16(addr: int, value: int, /) -> None:
     """
     Writes an unsigned integer to 2 bytes.
     Overflowing values are truncated.
@@ -113,7 +113,7 @@ def write_u16(addr: int, value: int, /):
     """
 
 
-def write_u32(addr: int, value: int, /):
+def write_u32(addr: int, value: int, /) -> None:
     """
     Writes an unsigned integer to 4 bytes.
     Overflowing values are truncated.
@@ -123,7 +123,7 @@ def write_u32(addr: int, value: int, /):
     """
 
 
-def write_u64(addr: int, value: int, /):
+def write_u64(addr: int, value: int, /) -> None:
     """
     Writes an unsigned integer to 8 bytes.
     Overflowing values are truncated.
@@ -133,7 +133,7 @@ def write_u64(addr: int, value: int, /):
     """
 
 
-def write_s8(addr: int, value: int, /):
+def write_s8(addr: int, value: int, /) -> None:
     """
     Writes a signed integer to 1 byte.
     Overflowing values are truncated.
@@ -143,7 +143,7 @@ def write_s8(addr: int, value: int, /):
     """
 
 
-def write_s16(addr: int, value: int, /):
+def write_s16(addr: int, value: int, /) -> None:
     """
     Writes a signed integer to 2 bytes.
     Overflowing values are truncated.
@@ -153,7 +153,7 @@ def write_s16(addr: int, value: int, /):
     """
 
 
-def write_s32(addr: int, value: int, /):
+def write_s32(addr: int, value: int, /) -> None:
     """
     Writes a signed integer to 4 bytes.
     Overflowing values are truncated.
@@ -163,7 +163,7 @@ def write_s32(addr: int, value: int, /):
     """
 
 
-def write_s64(addr: int, value: int, /):
+def write_s64(addr: int, value: int, /) -> None:
     """
     Writes a signed integer to 8 bytes.
     Overflowing values are truncated.
@@ -173,7 +173,7 @@ def write_s64(addr: int, value: int, /):
     """
 
 
-def write_f32(addr: int, value: float, /):
+def write_f32(addr: int, value: float, /) -> None:
     """
     Writes a floating point number to 4 bytes.
     Overflowing values are truncated.
@@ -183,7 +183,7 @@ def write_f32(addr: int, value: float, /):
     """
 
 
-def write_f64(addr: int, value: float, /):
+def write_f64(addr: int, value: float, /) -> None:
     """
     Writes a floating point number to 8 bytes.
     Overflowing values are truncated.

--- a/python-stubs/dolphin/savestate.pyi
+++ b/python-stubs/dolphin/savestate.pyi
@@ -3,14 +3,14 @@ Module for creating and loading savestates.
 """
 
 
-def save_to_slot(slot: int, /):
+def save_to_slot(slot: int, /) -> None:
     """
     Saves a savestate to the given slot.
     The slot number must be between 0 and 99.
     """
 
 
-def save_to_file(filename: str, /):
+def save_to_file(filename: str, /) -> None:
     """
     Saves a savestate to the given file.
     """
@@ -22,20 +22,20 @@ def save_to_bytes() -> bytes:
     """
 
 
-def load_from_slot(slot: int, /):
+def load_from_slot(slot: int, /) -> None:
     """
     Loads a savestate from the given slot.
     The slot number must be between 0 and 99.
     """
 
 
-def load_from_file(filename: str, /):
+def load_from_file(filename: str, /) -> None:
     """
     Loads a savestate from the given file.
     """
 
 
-def load_from_bytes(state_bytes: bytes, /):
+def load_from_bytes(state_bytes: bytes, /) -> None:
     """
     Loads a savestate from the given bytes.
     """


### PR DESCRIPTION
First of, thanks for this fork, it's been easy to use, in parts thanks to the stubs. However, there's a few issues with those:

A handful of improvements to make the stubs complete, more usable and follow up-to-date stub typing standards:
- Explicitely re-export imports meant to be re-exported
- Now passes mypy, pyright and Flake8-PYI
- Explicitely return `None`. Otherwise mypy infers as `Any` and pyright as `Unknown`
- Mark type-only classes with `type_check_only`. Those classes are type references and cannot be imported at runtime.
- Prefer `|` rather than `Union` or `Optional`
- Prefer `collections.abc.Callable` over `typing.Callable`
- Fixed the syntax error at `memorybreakpoint`'s return type
- Explicitely type `Position` as a `TypeAlias`
- Fixed the type of optional parameters that have a default value of `None`