### PR TITLE
Add pause and resume methods for scripting

### DIFF
--- a/Source/Core/Scripting/Python/Modules/emulationmodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/emulationmodule.cpp
@@ -19,6 +19,24 @@ struct EmulationModuleState
   Core::System* system;
 };
 
+static PyObject* EmulationResume(PyObject* self)
+{
+  EmulationModuleState* state = Py::GetState<EmulationModuleState>(self);
+  if(Core::GetState(*state->system) == Core::State::Paused) {
+    Core::SetState(*state->system, Core::State::Running);
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject* EmulationPause(PyObject* self)
+{
+  EmulationModuleState* state = Py::GetState<EmulationModuleState>(self);
+  if(Core::GetState(*state->system) == Core::State::Running) {
+    Core::SetState(*state->system, Core::State::Paused);
+  }
+  Py_RETURN_NONE;
+}
+
 static PyObject* EmulationReset(PyObject* self)
 {
   EmulationModuleState* state = Py::GetState<EmulationModuleState>(self);
@@ -39,6 +57,8 @@ static void SetupEmulationModule(PyObject* module, EmulationModuleState* state)
 PyMODINIT_FUNC PyInit_emulation()
 {
   static PyMethodDef methods[] = {
+      Py::MakeMethodDef<EmulationResume>("resume"),
+      Py::MakeMethodDef<EmulationPause>("pause"),
       Py::MakeMethodDef<EmulationReset>("reset"),
 
       {nullptr, nullptr, 0, nullptr}  // Sentinel

--- a/python-stubs/dolphin/emulation.pyi
+++ b/python-stubs/dolphin/emulation.pyi
@@ -3,6 +3,16 @@ Module for controlling the emulation.
 """
 
 
+def pause() -> None:
+    """
+    Pauses the emulation. Acts like tapping the "Pause"-Button.
+    """
+
+def resume() -> None:
+    """ 
+    Resumes the emulation. Acts like tapping the "Play"-Button.
+    """
+
 def reset() -> None:
     """
     Resets the emulation. Acts like tapping the "Reset"-Button.


### PR DESCRIPTION
Basically I added two methods to manipulate the emulation state. "Pause" pauses the emulation and "Resume" resumes it.