### PR TITLE
Add github workflows for automatic builds of Dolphin

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,97 @@
+name: Build Linux Dolphin
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.13
+
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt upgrade
+          sudo apt install libxi-dev
+          sudo apt install libegl1-mesa-dev
+          sudo apt install ffmpeg
+          sudo apt install libudev-dev
+          sudo apt install libevdev-dev
+          sudo apt install build-essential
+          sudo apt install cmake
+          sudo apt install git
+          sudo apt install qt6-base-dev qt6-tools-dev libqt6svg6-dev
+          sudo apt install libavcodec-dev
+          sudo apt install libavformat-dev
+          sudo apt install libcurl4-openssl-dev
+          sudo apt install libdbus-1-dev
+          sudo apt install libglew-dev
+          sudo apt install libgtk-3-dev
+          sudo apt install libopenal-dev
+          sudo apt install libreadline-dev
+          sudo apt install libxrandr-dev
+          sudo apt install libxi-dev
+          sudo apt install libxinerama-dev
+          sudo apt install libx11-dev
+          sudo apt install libasound2-dev
+          sudo apt install libpulse-dev
+          sudo apt install libfreetype6-dev
+          sudo apt install libfontconfig1-dev
+          sudo apt install libpng-dev
+          sudo apt install libjpeg-dev
+          sudo apt install libz-dev
+          sudo apt install libxext-dev
+          sudo apt install libxrender-dev
+          sudo apt install libglu1-mesa-dev
+          sudo apt install libgtkglext1-dev
+          sudo apt install libgtest-dev
+          sudo apt install libgmp-dev
+          sudo apt install liblz4-dev
+          sudo apt install liblzma-dev
+          sudo apt install libsnappy-dev
+          sudo apt install libtinyxml2-dev
+          sudo apt install libxi-dev
+          sudo apt install libxrandr-dev
+          sudo apt install libxinerama-dev
+          sudo apt install libx11-xcb-dev
+          sudo apt install libxcb-glx0-dev
+          sudo apt install libxcb1-dev
+          sudo apt install libxcb-dri3-dev
+          sudo apt install libxcb-dri2-0-dev
+          sudo apt install libxcb-xfixes0-dev
+          sudo apt install libxcb-randr0-dev
+          sudo apt install libxcb-keysyms1-dev
+          sudo apt install libxcb-image0-dev
+          sudo apt install libxcb-shape0-dev
+          sudo apt install libxcb-xinerama0-dev
+          sudo apt install libxcb-util-dev
+          sudo apt install libxcb-icccm4-dev
+          sudo apt install libxcb-keysyms1-dev
+          sudo apt install libxcb-xkb-dev
+          sudo apt install libxkbcommon-dev
+          sudo apt install libxkbcommon-x11-dev
+
+      - name: Build Dolphin
+        run: |
+          # On Ubuntu some include files are missing for Qt6, we copy those manually
+          # Hacky, but it works anyways
+          sudo cp -r Externals/Qt/Qt6.5.1/x64/include/QtGui/6.5.1/QtGui/qpa/ /usr/include/
+          cmake -Bbuild . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DUSE_SYSTEM_LIBS=OFF -DCMAKE_BUILD_TYPE=Release
+          cd build
+          make -j$(nproc)
+          cp -r ../Data/Sys/ Binaries/
+          tar -czf dolphin_linux.tar.gz Binaries/
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: DolphinLinux
+          path: build/dolphin_linux.tar.gz

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,13 @@
 name: Build Linux Dolphin
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -91,7 +91,7 @@ jobs:
           # On Ubuntu some include files are missing for Qt6, we copy those manually
           # Hacky, but it works anyways
           sudo cp -r Externals/Qt/Qt6.5.1/x64/include/QtGui/6.5.1/QtGui/qpa/ /usr/include/
-          cmake -Bbuild . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DUSE_SYSTEM_LIBS=OFF -DCMAKE_BUILD_TYPE=Release
+          cmake -Bbuild . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DLINUX_LOCAL_DEV=true -DUSE_SYSTEM_LIBS=OFF -DCMAKE_BUILD_TYPE=Release
           cd build
           make -j$(nproc)
           cp -r ../Data/Sys/ Binaries/

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -27,64 +27,62 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update && sudo apt upgrade
-          sudo apt install libxi-dev
-          sudo apt install libegl1-mesa-dev
-          sudo apt install ffmpeg
-          sudo apt install libudev-dev
-          sudo apt install libevdev-dev
-          sudo apt install build-essential
-          sudo apt install cmake
-          sudo apt install git
-          sudo apt install qt6-base-dev qt6-tools-dev libqt6svg6-dev
-          sudo apt install libavcodec-dev
-          sudo apt install libavformat-dev
-          sudo apt install libcurl4-openssl-dev
-          sudo apt install libdbus-1-dev
-          sudo apt install libglew-dev
-          sudo apt install libgtk-3-dev
-          sudo apt install libopenal-dev
-          sudo apt install libreadline-dev
-          sudo apt install libxrandr-dev
-          sudo apt install libxi-dev
-          sudo apt install libxinerama-dev
-          sudo apt install libx11-dev
-          sudo apt install libasound2-dev
-          sudo apt install libpulse-dev
-          sudo apt install libfreetype6-dev
-          sudo apt install libfontconfig1-dev
-          sudo apt install libpng-dev
-          sudo apt install libjpeg-dev
-          sudo apt install libz-dev
-          sudo apt install libxext-dev
-          sudo apt install libxrender-dev
-          sudo apt install libglu1-mesa-dev
-          sudo apt install libgtkglext1-dev
-          sudo apt install libgtest-dev
-          sudo apt install libgmp-dev
-          sudo apt install liblz4-dev
-          sudo apt install liblzma-dev
-          sudo apt install libsnappy-dev
-          sudo apt install libtinyxml2-dev
-          sudo apt install libxi-dev
-          sudo apt install libxrandr-dev
-          sudo apt install libxinerama-dev
-          sudo apt install libx11-xcb-dev
-          sudo apt install libxcb-glx0-dev
-          sudo apt install libxcb1-dev
-          sudo apt install libxcb-dri3-dev
-          sudo apt install libxcb-dri2-0-dev
-          sudo apt install libxcb-xfixes0-dev
-          sudo apt install libxcb-randr0-dev
-          sudo apt install libxcb-keysyms1-dev
-          sudo apt install libxcb-image0-dev
-          sudo apt install libxcb-shape0-dev
-          sudo apt install libxcb-xinerama0-dev
-          sudo apt install libxcb-util-dev
-          sudo apt install libxcb-icccm4-dev
-          sudo apt install libxcb-keysyms1-dev
-          sudo apt install libxcb-xkb-dev
-          sudo apt install libxkbcommon-dev
-          sudo apt install libxkbcommon-x11-dev
+          sudo apt install \
+            libegl1-mesa-dev \
+            ffmpeg \
+            libudev-dev \
+            libevdev-dev \
+            build-essential \
+            cmake \
+            qt6-base-dev \
+            qt6-tools-dev \
+            libqt6svg6-dev \
+            libavcodec-dev \
+            libavformat-dev \
+            libcurl4-openssl-dev \
+            libdbus-1-dev \
+            libglew-dev \
+            libgtk-3-dev \
+            libopenal-dev \
+            libreadline-dev \
+            libxrandr-dev \
+            libx11-dev \
+            libasound2-dev \
+            libpulse-dev \
+            libfreetype6-dev \
+            libfontconfig1-dev \
+            libpng-dev \
+            libjpeg-dev \
+            libz-dev \
+            libxext-dev \
+            libxrender-dev \
+            libglu1-mesa-dev \
+            libgtkglext1-dev \
+            libgtest-dev \
+            libgmp-dev \
+            liblz4-dev \
+            liblzma-dev \
+            libsnappy-dev \
+            libtinyxml2-dev \
+            libxi-dev \
+            libxinerama-dev \
+            libx11-xcb-dev \
+            libxcb-glx0-dev \
+            libxcb1-dev \
+            libxcb-dri3-dev \
+            libxcb-dri2-0-dev \
+            libxcb-xfixes0-dev \
+            libxcb-randr0-dev \
+            libxcb-keysyms1-dev \
+            libxcb-image0-dev \
+            libxcb-shape0-dev \
+            libxcb-xinerama0-dev \
+            libxcb-util-dev \
+            libxcb-icccm4-dev \
+            libxcb-keysyms1-dev \
+            libxcb-xkb-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev
 
       - name: Build Dolphin
         run: |
@@ -95,10 +93,9 @@ jobs:
           cd build
           make -j$(nproc)
           cp -r ../Data/Sys/ Binaries/
-          tar -czf dolphin_linux.tar.gz Binaries/
 
       - name: Upload Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: DolphinLinux
-          path: build/dolphin_linux.tar.gz
+          path: build/Binaries

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,6 +1,13 @@
 name: Build Mac OS Dolphin
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -18,20 +18,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: macos-latest
+          - runs-on: macos-15
             arch: arm64
     runs-on: ${{ matrix.runs-on }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
       - name: Install Qt
         run: |
           brew update
-          brew install qt
+          # Creating a new tap to install an older version of qt (the newer ones have build issues), for now 6.9.3.
+          # To grab a different version, change the git hash below
+          brew tap-new workflow/homebrew-custom
+          curl -o /tmp/qt.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/63d2e0609cdc80b0b96472721f9adf55bd74696b/Formula/q/qt.rb
+          mv /tmp/qt.rb $(brew --repo workflow/homebrew-custom)/Formula/qt.rb
+          brew install workflow/custom/qt
 
       - name: Configure Dolphin
         run: |
@@ -53,7 +58,7 @@ jobs:
           tar -czf dolphin_mac.tar.gz Binaries/
 
       - name: Upload Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: DolphinMac-${{ matrix.arch }}
           path: build/dolphin_mac.tar.gz

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,0 +1,52 @@
+name: Build Mac OS Dolphin
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    name: "${{ matrix.runs-on }} • ${{ matrix.arch }}"
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        include:
+          - runs-on: macos-latest
+            arch: arm64
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install Qt
+        run: |
+          brew update
+          brew install qt
+
+      - name: Configure Dolphin
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DENABLE_AUTOUPDATE=OFF
+          tar -czf dolphin_mac.tar.gz Binaries/
+
+      - name: Try Building Dolphin
+        run: |
+          cd build
+          make -j$(sysctl -n hw.logicalcpu)
+        continue-on-error: true
+
+      - name: Try Building Dolphin Again
+        run: |
+          cd build
+          make -j$(sysctl -n hw.logicalcpu)
+          tar -czf dolphin_mac.tar.gz Binaries/
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: DolphinMac-${{ matrix.arch }}
+          path: build/dolphin_mac.tar.gz

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -31,12 +31,7 @@ jobs:
       - name: Install Qt
         run: |
           brew update
-          # Creating a new tap to install an older version of qt (the newer ones have build issues), for now 6.9.3.
-          # To grab a different version, change the git hash below
-          brew tap-new workflow/homebrew-custom
-          curl -o /tmp/qt.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/63d2e0609cdc80b0b96472721f9adf55bd74696b/Formula/q/qt.rb
-          mv /tmp/qt.rb $(brew --repo workflow/homebrew-custom)/Formula/qt.rb
-          brew install workflow/custom/qt
+          brew install qt
 
       - name: Configure Dolphin
         run: |

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 
@@ -23,10 +23,9 @@ jobs:
         run: |
           cmake -Bbuild . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release
           cmake --build build --config Release -- /m
-          ls
 
       - name: Upload Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: DolphinWin
           path: Binary

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,6 +1,13 @@
 name: Build Win Dolphin
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -12,11 +12,6 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.13
-
       - name: Build Dolphin
         run: |
           cmake -Bbuild . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,0 +1,30 @@
+name: Build Win Dolphin
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.13
+
+      - name: Build Dolphin
+        run: |
+          cmake -Bbuild . -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release -- /m
+          ls
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: DolphinWin
+          path: Binary

--- a/Source/Core/Core/API/Gui.cpp
+++ b/Source/Core/Core/API/Gui.cpp
@@ -94,7 +94,6 @@ void Gui::DrawCircleFilled(const Vec2f center, float radius, u32 color, int num_
   GUI_DRAW_DEFERRED(AddCircleFilled(center, radius, ARGBToABGR(color), num_segments));
 }
 
-// lol
 void Gui::DrawText2(const Vec2f pos, u32 color, std::string text)
 {
   GUI_DRAW_DEFERRED(AddText(pos, ARGBToABGR(color), text.c_str()));

--- a/Source/Core/Core/API/Gui.cpp
+++ b/Source/Core/Core/API/Gui.cpp
@@ -94,7 +94,8 @@ void Gui::DrawCircleFilled(const Vec2f center, float radius, u32 color, int num_
   GUI_DRAW_DEFERRED(AddCircleFilled(center, radius, ARGBToABGR(color), num_segments));
 }
 
-void Gui::DrawText(const Vec2f pos, u32 color, std::string text)
+// lol
+void Gui::DrawText2(const Vec2f pos, u32 color, std::string text)
 {
   GUI_DRAW_DEFERRED(AddText(pos, ARGBToABGR(color), text.c_str()));
 }

--- a/Source/Core/Core/API/Gui.h
+++ b/Source/Core/Core/API/Gui.h
@@ -36,7 +36,7 @@ public:
   void DrawTriangleFilled(const Vec2f a, const Vec2f b, const Vec2f c, u32 color);
   void DrawCircle(const Vec2f center, float radius, u32 color, int num_segments = 12, float thickness = 1.0f);
   void DrawCircleFilled(const Vec2f center, float radius, u32 color, int num_segments = 12);
-  void DrawText(const Vec2f pos, u32 color, std::string text);
+  void DrawText2(const Vec2f pos, u32 color, std::string text);
   void DrawPolyline(const std::vector<Vec2f> points, u32 color, bool closed, float thickness);
   void DrawConvexPolyFilled(const std::vector<Vec2f> points, u32 color);
 

--- a/Source/Core/Scripting/CMakeLists.txt
+++ b/Source/Core/Scripting/CMakeLists.txt
@@ -30,7 +30,17 @@ add_library(scripting
   Python/Utils/object_wrapper.h
 )
 
-find_package(Python3 REQUIRED COMPONENTS Development)
+if(WIN32)
+  set(Python3_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/Externals/python/x64/include")
+  set(Python3_LIBRARIES 
+    "${CMAKE_SOURCE_DIR}/Externals/python/x64/libs/python3.lib"
+    "${CMAKE_SOURCE_DIR}/Externals/python/x64/libs/python3_d.lib"
+    "${CMAKE_SOURCE_DIR}/Externals/python/x64/libs/python312.lib"
+    "${CMAKE_SOURCE_DIR}/Externals/python/x64/libs/python312_d.lib"
+  )
+else()
+  find_package(Python3 REQUIRED COMPONENTS Development)
+endif()
 include_directories(${Python3_INCLUDE_DIRS})
 # TODO imgui shouldn't be here
 target_link_libraries(scripting PRIVATE ${Python3_LIBRARIES} imgui core)

--- a/Source/Core/Scripting/Python/Modules/guimodule.cpp
+++ b/Source/Core/Scripting/Python/Modules/guimodule.cpp
@@ -101,7 +101,7 @@ static void draw_circle_filled(PyObject* self, float centerX, float centerY, flo
 static void draw_text(PyObject* self, float posX, float posY, u32 color, const char* text)
 {
   GuiModuleState* state = Py::GetState<GuiModuleState>(self);
-  state->gui->DrawText({posX, posY}, color, std::string(text));
+  state->gui->DrawText2({posX, posY}, color, std::string(text));
 }
 
 static PyObject* draw_polyline(PyObject* self, PyObject* args)


### PR DESCRIPTION
Adds workflows for building Dolphin on Linux, Mac OS and Windows as discussed in #58 . Originally I wanted to merge them into a single file but I found them different enough that I made separate files for each OS.
Alongside building, the workflows also upload the builds. The one for Linux is built on Ubuntu 24.04 so it'll only work on that version specifically (due to different package versions). The one for Windows runs fine (the executable gets built on folder `Release` so it has to be manually copied to the root directory, alongside the python embeded files like before).

I had to make a few changes in the source code though. In finding python libraries whenever `find_package` is attempted it uses the systems python libraries which didn't run for me on my Windows, so instead I included them manually from the one in `Externals/python`, let me know what you think.

As for the second change, I encountered a very strange issue. If you attempt to build the project with cmake on Windows, you'll encounter symbol error on `Gui::DrawText`, which should definitely exist and doesn't happen for other methods in `Gui`. If you change the name to something else (`Gui::DrawText2` in this case) the projects gets built successfully... Honestly a very odd issue and considering that this doesn't happen on Linux and Mac OS (and via solution) it's safe to assume that it's a bug with the compiler/linker/build system. Thankfully this doesn't change Python's API but if you dislike this I'll revert the changes but we'll also have to ditch Windows' workflow.

The Error:
```bash
     Creating library D:/a/dolphin/dolphin/build/Source/Core/DolphinQt/Release/Dolphin.lib and object D:/a/dolphin/dolphin/build/Source/Core/DolphinQt/Release/Dolphin.exp
scripting.lib(guimodule.obj) : error LNK2019: unresolved external symbol "public: void __cdecl API::Gui::DrawText(struct ImVec2,unsigned int,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >)" (?DrawText@Gui@API@@QEAAXUImVec2@@IV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z) referenced in function "public: static struct _object * __cdecl Py::PyCFunctionWrapperStruct<void (__cdecl*)(struct _object *,float,float,unsigned int,char const *),&void __cdecl PyScripting::draw_text(struct _object *,float,float,unsigned int,char const *)>::PyCFunctionWrapper(struct _object *,struct _object *)" (?PyCFunctionWrapper@?$PyCFunctionWrapperStruct@P6AXPEAU_object@@MMIPEBD@Z$1?draw_text@PyScripting@@YAX0MMI1@Z@Py@@SAPEAU_object@@PEAU3@0@Z) [D:\a\dolphin\dolphin\build\Source\Core\DolphinQt\dolphin-emu.vcxproj]
D:\a\dolphin\dolphin\Binary\x64\Release\Dolphin.exe : fatal error LNK1120: 1 unresolved externals [D:\a\dolphin\dolphin\build\Source\Core\DolphinQt\dolphin-emu.vcxproj]
```

And also, merry Christmas!